### PR TITLE
Copy coverage data to circle-ci's artifacts folder.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+dependencies:
+  post:
+    - bower install
+test:
+  post:
+    # Save coverage data.
+    - cp -r ./coverage/* $CIRCLE_ARTIFACTS

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "nibelung.js",
   "scripts": {
-    "test": "karma start",
-    "postinstall": "bower install"
+    "test": "karma start"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Also handle bower installation separately from npm install.