### PR TITLE
Several private mode fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "nibelung",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "homepage": "https://github.com/rangle/nibelung",
   "main": "nibelung.js",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
   "name": "nibelung",
-  "version": "0.2.5",
-  "description": "",
+  "version": "0.2.6",
+  "description": "Caching library backed by browser local storage.",
+  "keywords": [
+    "Cache",
+    "localStorage",
+    "sessionStorage",
+    "TTL"
+  ],
   "main": "nibelung.js",
   "scripts": {
     "test": "karma start"


### PR DESCRIPTION
- Fixed an issue where in private mode, creating a hoard whose namespace was a prefix of 'clear' or 'removeItem' would cause getLatest() to throw an exception.
- Added code to ignore data inserted into the storage instance directly (i.e. not through Nibelung)
- Fixed an issue where a caller-supplied logger would not get called in certain cases.
- Added unit tests for all this stuff.