### PR TITLE
Added a simple data versioning strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Adds the following features to HTML localStorage and sessionStorage
 * Namespacing.
 * The ability to cap the number of records (uses an LRU strategy).
 * A simpler event API.
+* Basic version change detection.
 
 ## Creating a Hoard:
 
@@ -53,6 +54,23 @@ The following options are supported:
   // any function that accepts a string argument. If omitted, no logs will be
   // generated.
   logger: function (message) { ... }
+
+  // Most useful with persistent === true. Checks the given version string
+  // against the current format of any previously saved records. If they don't
+  // match, the versionChangeHandler.onVersionChange() will be called.
+  version: '1',
+
+  // Most useful with persistent === true. If the given version differs from
+  // the version of previously-saved data, onVersionChange will be called with
+  // the new and old versions respectively.  Returning true from
+  // onVersionChange will cause the Hoard to be stamped with the new version;
+  // returning false leaves it unchanged.  This gives you the ability to
+  // react to version changes and handle them (e.g. by clearing the cache, or
+  // upgrading existing records to the new schema).
+  //
+  // As a convenience, we also provide nibelung.ClearingVersionChangeHandler in
+  // case you want to 'upgrade' by just deleting old data.
+  versionChangeHandler: { onVersionChange: function (expectedVersion, actualVersion )}
 }
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "nibelung",
-  "version": "0.2.6",
+  "version": "0.3.6",
   "homepage": "https://github.com/rangle/nibelung",
   "main": "nibelung.js",
   "authors": [

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,10 +36,10 @@ module.exports = function(config) {
       dir: 'coverage'
     },
     thresholdReporter: {
-      statements: 85,
-      branches: 60,
-      functions: 80,
-      lines: 85
+      statements: 92,
+      branches: 79,
+      functions: 92,
+      lines: 93
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nibelung",
-  "version": "0.2.6",
+  "version": "0.3.6",
   "description": "Caching library backed by browser local storage.",
   "keywords": [
     "Cache",


### PR DESCRIPTION
You can now specify a `version` field when creating a Hoard.  This version is simply an opaque string.  You can also specify a `versionChangeHandler` which gets called when the passed-in version does not match a saved version from a previous instance of that namespace.

You can implement a version change handling strategy of your choice in the `versionChangeHandler`, e.g. blowing away all records or migrating them to the new data schema.  Returning `true` from `versionChangeHandler` tells Nibelung that you've handled the change and causes it to stamp the namespace with the new version.

Supplied a default change handler that does nothing, for backwards compatibility.