### PR TITLE
updated clear() to clear the hoard's namespace, not the entire cache

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -38,7 +38,7 @@ module.exports = function(config) {
     thresholdReporter: {
       statements: 92,
       branches: 79,
-      functions: 92,
+      functions: 90,
       lines: 93
     }
   });

--- a/nibelung.js
+++ b/nibelung.js
@@ -54,7 +54,7 @@
 
     this.version = function version() {
       return _cache[fDATA_VERSION + namespace] || '';
-    }
+    };
 
     this.getOne = function getOne(key) {
       return this.get([key])[0];
@@ -86,7 +86,7 @@
       R.forEach(function(key) {
         _dropRecord(key);
       }, keys);
-    }
+    };
 
     /** Filters the keys by what's not already cached. */
     this.excludes = function excludes(keys) {
@@ -107,7 +107,7 @@
     };
 
     this.clear = function clear() {
-      _cache.clear();
+      _dropRecords(_getKeysByLastUpdateTime(_cache));
       __eventSinks[namespace].emit('CLEAR', undefined, _reentrancyProtector);
     };
 
@@ -275,14 +275,14 @@
   function DefaultClock() {
     this.now = function() {
       return Date.now();
-    }
+    };
   }
 
   // Protects emit calls against re-entrancy and exception-prone handlers.
   function DefaultReentrancyProtector() {
     this.protect = function(fn) {
       return window.setTimeout(fn, 0);
-    }
+    };
   }
 
   // Checks for situations where local storage is unavailable.
@@ -291,7 +291,7 @@
       // Test that we can actually use the storage; will throw an exception if
       // we can't.
       storage.setItem('test', true);
-    }
+    };
   }
 
   // This handler is called when you specify an options.version which is
@@ -305,7 +305,7 @@
       actualVersion) {
       // Default behaviour: do nothing.
       return false;
-    }
+    };
   }
 
   // An instance of this handler can be supplied in the options
@@ -318,7 +318,7 @@
       actualVersion) {
       hoard.clear();
       return true;
-    }
+    };
   }
 
   function EventSink(legalEvents) {
@@ -333,7 +333,7 @@
       }
 
       _handlers[event].push(handler);
-    }
+    };
 
     this.off = function off(event, handler) {
       _assertLegalEvent(event);
@@ -341,7 +341,7 @@
       if (_handlers[event]) {
         _handlers[event] = R.reject(R.eq(handler), _handlers[event]);
       }
-    }
+    };
 
     this.emit = function emit(event, data, reentrancyProtector) {
       _assertLegalEvent(event);
@@ -354,7 +354,7 @@
           handler(event, data);
         }, 0);
       }, _handlers[event]);
-    }
+    };
 
     function _assertLegalEvent(event) {
       if (!R.contains(event, _legalEvents)) {

--- a/nibelung.test.js
+++ b/nibelung.test.js
@@ -44,6 +44,16 @@ describe('Hoard', function () {
     expect(hoard.getOne(testItems[0].id)).to.eql(undefined);
   });
 
+  it('can clear all its items', function () {
+    hoard.put(testItems, 'id');
+    expect(hoard.get(['a', 'b'])).to.eql(testItems);
+
+    hoard.clear();
+    expect(hoard.get(['a'])).to.eql([]);
+    expect(hoard.get(['b'])).to.eql([]);
+    expect(hoard.get(['a', 'b'])).to.eql([]);
+  });
+
   it('can tell who\'s not in the hoard', function () {
     hoard.put(testItems, 'id');
     expect(hoard.excludes(['a', 'b', 'c'])).to.eql(['c']);


### PR DESCRIPTION
Let me know what you think @SethDavenport 

I'm still not sure I 100% understand the architecture, but this feels right to clear out an entire HttpHoard.

Also I can move the semi-colon fixes to a different PR if needed.