### PR TITLE
Update nibelung.js

### DIFF
--- a/nibelung.js
+++ b/nibelung.js
@@ -78,8 +78,6 @@
       R.forEach(function (value) {
         _put(value[keyName], value);
       }, values);
-
-      _enforceMaxRecords();
     };
 
     this.remove = function remove(keys) {
@@ -222,6 +220,7 @@
       var cacheKey = _wrapKey(key);
       _cache[cacheKey] = _wrapValue(cacheKey, value);
       __eventSinks[namespace].emit('PUT', value, _reentrancyProtector);
+      _enforceMaxRecords();
     }
 
     function _keyExists(key) {


### PR DESCRIPTION
@SethDavenport 
Max records is not maintained when `putOne()` function is called. When we use cache service for `$http` in Angular, Uncaught DOM exception is is thrown since session storage becomes full.
Issues reported:
#32 #31 

Moving the `_enforceMaxRecords()` function call to` _put()` since the maxRecords is not maintained for `putOne()` function call.